### PR TITLE
Add memory management and utility functions to ImageSreamIO.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(ImageStreamIO LANGUAGES C)
 
+add_compile_options(-Ofast)
+
 add_library(ImageStreamIO SHARED ImageStreamIO.c)
 target_include_directories (ImageStreamIO PUBLIC
 "${PROJECT_SOURCE_DIR}/src")

--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -112,7 +112,7 @@ int ImageStreamIO_printERROR(const char *file, const char *func, int line, char 
               fprintf(stderr,"C Error: %s\n", buff );
            }
            else
-             fprintf(stderr,"Unknown C Error\n");*/
+             fprintf(stderr,"Unknown C Error\n");
         #else
            //GNU strerror_r does not necessarily use buff, and uses errno to report errors.
            int _errno = errno;

--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -107,7 +107,7 @@ int ImageStreamIO_printERROR(const char *file, const char *func, int line, char 
         
         //Test for which version of strerror_r we're using (XSI or GNU)
         #if ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !defined(_GNU_SOURCE))
-           if( strerror_r( errno, buff, 256 ) == 0 ) 
+           if( strerror_r( errno, buff, sizeof(buff) ) == 0 ) 
            {
               fprintf(stderr,"C Error: %s\n", buff );
            }
@@ -117,7 +117,7 @@ int ImageStreamIO_printERROR(const char *file, const char *func, int line, char 
            //GNU strerror_r does not necessarily use buff, and uses errno to report errors.
            int _errno = errno;
            errno = 0;
-           char * estr = strerror_r( _errno, buff, 256 );
+           char * estr = strerror_r( _errno, buff, sizeof(buff) );
         
            if(errno == 0) 
               fprintf(stderr,"%c[%d;%dmC Error: %s%c[%d;m\n", (char) 27, 1, 31, estr, 27, 0 );

--- a/ImageStreamIO.h
+++ b/ImageStreamIO.h
@@ -16,6 +16,8 @@
 #ifndef _IMAGESTREAMIO_H
 #define _IMAGESTREAMIO_H
  
+#include "ImageStruct.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -27,9 +29,49 @@ int_fast8_t init_ImageStreamIO();
 
 
 
+
 /* =============================================================================================== */
 /* =============================================================================================== */
-/** @name ImageStreamIO - 1. READ / WRITE STREAM                                                   */                  
+/** @name ImageStreamIO - 0. Utilities                                                             */                           
+/**@{                                                                                              */
+/* =============================================================================================== */
+/* =============================================================================================== */
+
+/** @brief Get the standard stream filename.
+  * 
+  * Fills in the \p file_name string with the standard shared memory image path, e.g.
+  *  \code
+  *    char file_name[64];
+  *    ImageStreamIO_filename(file_name, 64, "image00");
+  *    printf("%s\n", file_name);
+  *  \endcode
+  * produces the output:
+  *  \verbatim
+  *    /tmp/image00.im.shm 
+  8  \endverbatim
+  *
+  * \returns 0 on success
+  * \returns -1 on error
+  */
+int ImageStreamIO_filename( char * file_name,    ///< [out] the file name string to fill in
+                            size_t ssz,          ///< [in] the allocated size of file_name
+                            const char * im_name ///< [in] the image name
+                          );
+                            
+/** @brief Get the size in bytes from the data type code. 
+  */
+int ImageStreamIO_typesize( uint8_t atype /**< [in] the type code (see ImageStruct.h*/);
+
+/** @brief Get the FITSIO BITPIX from the data type code. 
+  */
+int ImageStreamIO_bitpix( uint8_t atype /**< [in] the type code (see ImageStruct.h*/);
+
+///@}
+
+/* =============================================================================================== */
+/* =============================================================================================== */
+/** @name ImageStreamIO - 1. READ / WRITE STREAM                                                   */               
+/**@{                                                                                              */
 /* =============================================================================================== */
 /* =============================================================================================== */
 
@@ -43,35 +85,168 @@ int ImageStreamIO_createIm( IMAGE *image,      ///< [out] IMAGE structure which 
                             int NBkw           ///< [in] the number of keywords to allocate.
                           );
 
+/** @brief Deallocate and remove an IMAGE structure.
+  *
+  * For a shared image:
+  * Closes all semaphores, deallcoates sem pointers,
+  * and removes associated files. Unmaps the shared memory
+  * segment, and finally removes the file. Sets the metadata and
+  * keyword pointers to NULL.
+  * 
+  * For a non-shred image:
+  * Deallocates all arrays and sets pointers to NULL.
+  * 
+  * \returns 0 on success
+  * \returns -1 on an error (currently no checks done)
+  * 
+  */
+int ImageStreamIO_destroyIm( IMAGE *image /**< [in] The IMAGE structure to deallocate and remove from the system.*/);
+
+/** @brief Connect to an existing shared memory image stream 
+  * 
+  * Wrapper for  \ref ImageStreamIO_read_sharedmem_image_toIMAGE
+  */
+int ImageStreamIO_openIm( IMAGE *image,    ///< [out] IMAGE structure which will be attached to the existing IMAGE
+                          const char *name ///< [in] the name of the shared memory file will be SHAREDMEMDIR/<name>_im.shm
+                        );
+
 /** @brief Read / connect to existing shared memory image stream */
-long ImageStreamIO_read_sharedmem_image_toIMAGE( const char *name, ///< [in] the name of the shared memory file to access, as in SHAREDMEMDIR/<name>_im.shm
-                                                 IMAGE *image      ///< [out] the IMAGE structure to connect to the stream
-                                               );
+int ImageStreamIO_read_sharedmem_image_toIMAGE( const char *name, ///< [in] the name of the shared memory file to access, as in SHAREDMEMDIR/<name>_im.shm
+                                                IMAGE *image      ///< [out] the IMAGE structure to connect to the stream
+                                              );
 
 
+/** @brief Close a shared memmory image stream.
+  * 
+  * For use in clients, detaches and cleans up memory used by non-owner process.
+  * 
+  * \returns 0 on success
+  * \returns -1 on error
+  * 
+  */ 
+int ImageStreamIO_closeIm(IMAGE * image /**< [in] A real-time image structure which contains the image data and meta-data.*/);
+
+///@}
 
 /* =============================================================================================== */
 /* =============================================================================================== */
 /** @name ImageStreamIO - 2. MANAGE SEMAPHORES                                                     */
+/**@{                                                                                              */
 /* =============================================================================================== */
 /* =============================================================================================== */
 
-/** @brief Create shmim semaphores */
+/** @brief Create shmim semaphores 
+ *
+ * ## Purpose
+ * 
+ * Create semaphore of a shmim
+ * 
+ * ## Arguments
+ * 
+ * @param[in]
+ * image	IMAGE*
+ * 			pointer to shmim
+ * 
+ * @param[in]
+ * NBsem    number of semaphores to be created
+ */
 int ImageStreamIO_createsem(IMAGE *image, long NBsem);
 
-/** @brief Post all shmim semaphores */
+/** @brief Post all shmim semaphores 
+ *
+ * ## Purpose
+ * 
+ * Posts semaphore of a shmim
+ * if index < 0, post all semaphores
+ * 
+ * ## Arguments
+ * 
+ * @param[in]
+ * image	IMAGE*
+ * 			pointer to shmim
+ * 
+ * @param[in]
+ * index    semaphore index
+ * 			index of semaphore to be posted
+ *          if index=-1, post all semaphores
+ */
 long ImageStreamIO_sempost(IMAGE *image, long index);
 
-/** @brief Post all shmim semaphores except one */
+/** @brief Post all shmim semaphores except one 
+ *
+ * ## Purpose
+ * 
+ * Posts all semaphores of a shmim except one
+ * 
+ * ## Arguments
+ * 
+ * @param[in]
+ * image	IMAGE*
+ * 			pointer to shmim
+ * 
+ * @param[in]
+ * index    semaphore index
+ * 			index of semaphore to be excluded
+ */
 long ImageStreamIO_sempost_excl(IMAGE *image, long index);
 
-/** @brief Post shmim semaphores at regular time interval */
+/** @brief Post shmim semaphores at regular time interval 
+ *
+ * ## Purpose
+ * 
+ * Posts all semaphores of a shmim at regular time intervals
+ * 
+ * ## Arguments
+ * 
+ * @param[in]
+ * image	IMAGE*
+ * 			pointer to shmim
+ * 
+ * @param[in]
+ * index    semaphore index
+ * 			is =-1, post all semaphores
+ * 
+ * @param[in]
+ * dtus     time interval [us]
+ * 
+ */
 long ImageStreamIO_sempost_loop(IMAGE *image, long index, long dtus);
 
-/** @brief Wait for semaphore */
+/** @brief Wait for semaphore 
+ *
+ * ## Purpose
+ * 
+ * Wait on a shmim semaphore
+ * 
+ * ## Arguments
+ * 
+ * @param[in]
+ * image	IMAGE*
+ * 			pointer to shmim
+ * 
+ * @param[in]
+ * index    semaphore index
+ * 
+ */
 long ImageStreamIO_semwait(IMAGE *image, long index);
 
-/** @brief Flush all semaphores of a shmim */
+/** @brief Flush all semaphores of a shmim 
+ *
+ * ## Purpose
+ * 
+ * Flush shmim semaphore
+ * 
+ * ## Arguments
+ * 
+ * @param[in]
+ * image	IMAGE*
+ * 			pointer to shmim
+ * 
+ * @param[in]
+ * index    semaphore index
+ * 			flush all semaphores if index<0
+ * 
+ */
 long ImageStreamIO_semflush(IMAGE *image, long index);
 
 ///@}


### PR DESCRIPTION
Summary: Adds memory management and utility functions to ImageSreamIO.

Most of this is motivated by clients (like viewers) that need to be able to respond to changes, deal with not-yet-created images, restarts, etc.

Details:

Adds `#include "ImageStruct.h"` to `ImageStreamIO.h`, should mean that you only need to include `ImageStreamIO.h` Cleans up includes in `ImageStreamIO.c` accordingly

Adds utility functions:
- `ImageStreamIO_filename`: populates the standard filename
- `ImageStreamIO_typesize`: gets the size of the type
- `ImageStreamIO_bitpix`: gets the FITS BITPIX code for the type. NOTE: this adds dependency on fitsio.h!

Adds Management functions:
- `ImageStreamIO_destroyIm`: deallocates and removes an IMAGE structure.
- `ImageStreamIO_openIm`: a simple wrapper for `ImageStreamIO_read_sharedmem_image_toIMAGE`, gives more symmetric name
- `ImageStreamIO_closeIm`: opposite of _openIm.

The destroy and close functions were verifed with valgrind -- that is they leave no blocks behind.

Other changes of note:
- changed appropriate places to use `ImageStreamIO_filename` instead of `sprintf`.
- Changed `sprintf` to `snprintf` in several places.
- Changed `strcpy` to `strncpy` in several places
- Added feature tests in `ImageStreamIO_printERROR` for processing return val of `strerror_r`
- Added `#define` work around for old FITSIO without ULONGLONG (uint64_t) support.
- Removed uneccesary check for existence with double `sem_open` in `_createSem`.  `sem_open` already does exactly this.
- image->md[0].sem is now updated at end of _createSem to prevent early access by clients.
- Cleaned up doxygen stuff.  NOTE: do we want main part of function docs in .h or .c files?