### PR TITLE
Fix Python build for environments without CUDA

### DIFF
--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -13,7 +13,6 @@
 
 #define _GNU_SOURCE
 
-#include <malloc.h>
 #include <math.h>
 #include <pthread.h>
 #include <signal.h>

--- a/python_module/src/ImageStreamIOWrap.cpp
+++ b/python_module/src/ImageStreamIOWrap.cpp
@@ -151,13 +151,17 @@ py::array_t<T> convert_img(const IMAGE &img) {
 
   auto ret_buffer = py::array_t<T>(shape, strides);
   void *current_image = img.array.raw;
+  #ifdef HAVE_CUDA
   if (img.md->location == -1) {
+  #endif
     memcpy(ret_buffer.mutable_data(), current_image,
            img.md->nelement * sizeof(T));
+  #ifdef HAVE_CUDA
   } else {
     cudaMemcpy(ret_buffer.mutable_data(), current_image,
                img.md->nelement * sizeof(T), cudaMemcpyDeviceToHost);
   }
+  #endif
   return ret_buffer;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ class CMakeBuildExt(build_ext):
                         os.environ["CUDA_ROOT"])
                 ]
             cmake_args += ['-DUSE_CUDA=ON']
+        else:
+            cmake_args += ['-DUSE_CUDA=OFF']
 
         cmake_args += ['-Dpython_build=ON', '-Duse_hunter=ON']
 


### PR DESCRIPTION
Ensure USE_CUDA=OFF passed when CUDA not present, add guard for HAVE_CUDA around cudaMemcpy in ImageStreamIOWrap