### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ add_compile_options(-Ofast)
 
 add_library(${LIBNAME} SHARED ${SRCNAME}.c)
 
+# set -C99 flag for 'for' loop initial declartaions
+set_property(TARGET ${LIBNAME} PROPERTY C_STANDARD 99)
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(CFITSIO cfitsio)
 if(${CFITSIO_FOUND})


### PR DESCRIPTION
Adds property for C99 flag to ensure successful builds

In my case, without this my builds failed with, e.g.

```
/workspace/srcdir/ImageStreamIO/ImageStreamIO.c:1422:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for(int s = 0; s < image->md->sem; s++)
         ^
```