### PR TITLE
Load pybind11 in CMakeLists.txt for python_module to fix build

### DIFF
--- a/python_module/CMakeLists.txt
+++ b/python_module/CMakeLists.txt
@@ -5,10 +5,12 @@ project(ImageStreamIOWrap LANGUAGES CXX)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+find_package(pybind11)
+
 if(NOT TARGET pybind11)
   execute_process(COMMAND bash -c "${PYTHON_EXECUTABLE} -m pybind11 --includes"
                   OUTPUT_VARIABLE pybind11_inc)
-  execute_process(COMMAND bash -c "python3-config --extension-suffix"
+  execute_process(COMMAND bash -c "${PYTHON_EXECUTABLE} -c 'import sysconfig; print(sysconfig.get_config_var(\'EXT_SUFFIX\'))'"
                   OUTPUT_VARIABLE PYTHON_MODULE_EXTENSION)
   string(REPLACE "-I" "" pybind11_inc ${pybind11_inc})
   string(REPLACE " " ";" pybind11_inc ${pybind11_inc})


### PR DESCRIPTION
Two small changes:

- `python3-config` is not always available, and when it's missing the `PYTHON_MODULE_EXTENSION` variable is the empty string (so the module appears to install but is not importable)
- pybind11's cmake integration was not actually loaded when building the ImageStreamIOWrap python module with `pip`, so the other path of this conditional was not taken