### PR TITLE
Add missing [map] pointer update in ImageStreamIO.c ...

### DIFF
--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -1356,6 +1356,7 @@ errno_t ImageStreamIO_read_sharedmem_image_toIMAGE(
         map += sizeof(CBFRAMEMD) * image->md->CBsize;
 
         image->CBimdata = map;
+        map += ImageStreamIO_offset_data(image, map) * image->md->CBsize;
     }
     else
     {


### PR DESCRIPTION
… when opening existing shmim (ImageStreamIO_read_sharedmem_image_toIMAGE)

See comments in file diff

N.B. I accidentally pushed this to milk-org/ImageStreamIO dev branch, but reset that branch back to commit [f6a651f](https://github.com/milk-org/ImageStreamIO/commit/f6a651fca7c1c2cb9dee82225c084c28210c0812) soon after.