### PR TITLE
Add missing [map] pointer update in ImageStreamIO.c ...

### DIFF
--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -1356,6 +1356,7 @@ errno_t ImageStreamIO_read_sharedmem_image_toIMAGE(
         map += sizeof(CBFRAMEMD) * image->md->CBsize;
 
         image->CBimdata = map;
+        map += ImageStreamIO_offset_data(image, map) * image->md->CBsize;
     }
     else
     {


### PR DESCRIPTION
...  when opening existing shmim (ImageStreamIO_read_sharedmem_image_toIMAGE)

This is the analog to the statement
```
    map += datasharedsize * CBSize;
```
[here](https://github.com/milk-org/ImageStreamIO/blob/dev/ImageStreamIO.c#L928) in routine ImageStreamIO_createIm(...).