### PR TITLE
Compatility dao

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ if(USE_CUDA)
   target_compile_options(${LIBNAME} PUBLIC -DHAVE_CUDA)
 endif(USE_CUDA)
 
+if(DAO_COMPAT)
+  target_compile_options(${LIBNAME} PUBLIC -DDAO_COMPAT)
+endif(DAO_COMPAT)
 #
 # Python wrap.
 #

--- a/ImageStruct.h
+++ b/ImageStruct.h
@@ -158,6 +158,8 @@ extern "C" {
 #define ZAXIS_WAVELENGTH 0x30000  /**< wavelength coordinate */
 #define ZAXIS_MAPPING    0x40000  /**< mapping index */
 
+#define MAX_NB_PARTIAL_PACKET 512 /**< max number of partial packet used for partial write in teh SHM */
+
 /** @brief  Keyword
  * The IMAGE_KEYWORD structure includes :
  * 	- name
@@ -360,6 +362,13 @@ typedef struct
     uint64_t imdatamemsize; // image size [bytes]
 
     cudaIpcMemHandle_t cudaMemHandle;
+
+    // The following fields are used for partial write in the SHM
+    uint32_t lastPos;              /**< the 1st positon of the last write                                           */
+    uint32_t lastNb;               /**< the number of last write                                                    */
+    uint32_t packetNb;             /**< current partial packet write number                                         */
+    uint32_t packetTotal;          /**< expected total number of packet                                             */ 
+    uint64_t lastNbArray[MAX_NB_PARTIAL_PACKET]; /**< array containing the sub frame number                         */
 
 } IMAGE_METADATA;
 

--- a/ImageStruct.h
+++ b/ImageStruct.h
@@ -160,6 +160,7 @@ extern "C" {
 
 #define MAX_NB_PARTIAL_PACKET 512 /**< max number of partial packet used for partial write in teh SHM */
 
+
 /** @brief  Keyword
  * The IMAGE_KEYWORD structure includes :
  * 	- name
@@ -363,12 +364,14 @@ typedef struct
 
     cudaIpcMemHandle_t cudaMemHandle;
 
+#ifdef DAO_COMPAT
     // The following fields are used for partial write in the SHM
     uint32_t lastPos;              /**< the 1st positon of the last write                                           */
     uint32_t lastNb;               /**< the number of last write                                                    */
     uint32_t packetNb;             /**< current partial packet write number                                         */
     uint32_t packetTotal;          /**< expected total number of packet                                             */ 
     uint64_t lastNbArray[MAX_NB_PARTIAL_PACKET]; /**< array containing the sub frame number                         */
+#endif
 
 } IMAGE_METADATA;
 

--- a/ImageStruct.h
+++ b/ImageStruct.h
@@ -501,6 +501,9 @@ typedef struct /**< structure used to store data arrays                      */
         complex_float *CF;
         complex_double *CD;
 
+#ifdef DAO_COMPAT
+        void * V; // add so the cpp interface and reinterpret cast using templaces to required type.
+#endif
     } array; /**< pointer to data array */
 
 


### PR DESCRIPTION
I added 5 fields at the end of the IMAGE_METADATA structure into a #ifdef DAO_COMPAT. The DAO_COMPAT has been added in the CMakeList.txt. I defined another constant outside the DAO_COMPAT to limit the repetition of #ifdef.
The 5 fields are used in DAO and are used for partial write/read in the shared memory. They are missing to be 100% compatible with DAO.
If it is possible to remove the DAO_COMPAT for the long term maintenance it will be convenient.
