### PR TITLE
add direct formatting option to ImageKeyword struct with tests

### DIFF
--- a/ImCreate_cube.c
+++ b/ImCreate_cube.c
@@ -82,6 +82,10 @@ int main()
     strncpy(imarray.kw[2].value.valstr, "ImCreate_cube", KEYWORD_MAX_STRING-1);
     strncpy(imarray.kw[2].comment, "source value", KEYWORD_MAX_COMMENT-1);
 
+    strcpy(imarray.kw[3].name, "keyword_custom");
+    imarray.kw[3].type = 'F';
+    strcpy(imarray.kw[3].format, "%6.2f");
+    imarray.kw[3].value.numf = 12.335;
 
 	free(imsize);
 

--- a/ImCreate_img.c
+++ b/ImCreate_img.c
@@ -78,6 +78,12 @@ int main()
     imarray.kw[2].type = 'S';
     strcpy(imarray.kw[2].value.valstr, "Hello!");
 
+    strcpy(imarray.kw[3].name, "keyword_custom");
+    imarray.kw[3].type = 'F';
+    strcpy(imarray.kw[3].format, "%6.2f");
+    imarray.kw[3].value.numf = 12.335;
+
+
     float angle;
     float r;
     float r1;

--- a/ImageStruct.h
+++ b/ImageStruct.h
@@ -18,7 +18,7 @@
 #ifndef _IMAGESTRUCT_H
 #define _IMAGESTRUCT_H
 
-#define IMAGESTRUCT_VERSION "2.00"
+#define IMAGESTRUCT_VERSION "2.01"
 
 #define STRINGMAXLEN_IMAGE_NAME          80
 #define STRINGMAXLEN_FILE_NAME          200
@@ -26,6 +26,7 @@
 
 #define KEYWORD_MAX_STRING  16            /**< maximun size of the keyword's name */
 #define KEYWORD_MAX_COMMENT 80            /**< maximun size of a keyword's comment */
+#define KEYWORD_MAX_FORMAT  10            /**< maximun size of a keyword's format */
 
 // comment if no write history
 //#define IMAGESTRUCT_WRITEHISTORY
@@ -165,13 +166,14 @@ extern "C" {
  * The IMAGE_KEYWORD structure includes :
  * 	- name
  * 	- type
+ *  - (optional) formatter string
  * 	- value
  */
 typedef struct
 {
     char name[KEYWORD_MAX_STRING]; /**< keyword name                                                   */
-    char type;                     /**< N: unused, L: long, D: double, S: 16-char string               */
-    uint64_t : 0;                  // align array to 8-byte boundary for speed
+    char type;                     /**< N: unused, L: long, D: double, S: 16-char string, F: formatted */
+    char format[KEYWORD_MAX_FORMAT]; // String formatter for card when type is F
 
     union
     {

--- a/ImageStruct.h
+++ b/ImageStruct.h
@@ -26,7 +26,7 @@
 
 #define KEYWORD_MAX_STRING  16            /**< maximun size of the keyword's name */
 #define KEYWORD_MAX_COMMENT 80            /**< maximun size of a keyword's comment */
-#define KEYWORD_MAX_FORMAT  10            /**< maximun size of a keyword's format */
+#define KEYWORD_MAX_FORMAT   8            /**< maximun size of a keyword's format */
 
 // comment if no write history
 //#define IMAGESTRUCT_WRITEHISTORY


### PR DESCRIPTION
For example usage, see the code in the test files `ImCreate_cube.c` and `ImCreate_img.c`.

Key points:
* specify `F` keyword type for formatted keywords
* Format as added in the place of the space-padding `uint64` in the `ImageKeyword` struct. The number of bytes is, by default, set to `8` to match the original padding of the struct. 
    * This should be sufficient for all format strings as they are `%-16.16s`, which is 8 bytes, but if we need breathing room, we can save the format strings without the `%` since it is redundant.
* Struct version incremented to `2.00` -> `2.01`; this is not a breaking change, just a feature addition.

To fully implement these changes, code will need to be changed in milk (`save_fits.c`) and camstack.