### PR TITLE
added ifndefs for CLOCK_ISIO and FILEMODE (which is now FILEMODE_ISIO)

### DIFF
--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -43,7 +43,10 @@
 #endif
 
 // shared memory and semaphores file permission
-#define FILEMODE 0666
+// if FILEMODE_ISIO is not defined, set to a+rw
+#ifndef FILEMODE_ISIO
+    #define FILEMODE_ISIO 0666
+#endif
 
 #if defined NDEBUG
 #define DEBUG_TRACEPOINT_LOG(...)
@@ -1432,7 +1435,7 @@ errno_t ImageStreamIO_createIm_gpu(
         image->shmfd = open(SM_fname
                             // (O_CREAT|O_EXCL) flags force new file
                             , O_RDWR | O_CREAT | O_EXCL | O_TRUNC
-                            , (mode_t)FILEMODE
+                            , (mode_t)FILEMODE_ISIO
                            );
         if (image->shmfd == -1 && errno == EEXIST)
         {
@@ -1441,7 +1444,7 @@ errno_t ImageStreamIO_createIm_gpu(
             errno = 0;         // - ignore any error from unlink;
             image->shmfd = open(SM_fname  // - and try again ...
                                 , O_RDWR | O_CREAT | O_EXCL | O_TRUNC
-                                , (mode_t)FILEMODE
+                                , (mode_t)FILEMODE_ISIO
                                );
         }
         if (image->shmfd == -1)
@@ -2276,7 +2279,7 @@ long ImageStreamIO_UpdateIm_atime( IMAGE *image,
             image->md->wCBindex = 0;
             ++image->md->wCBcycle;
         }
-        
+
         //re-use ts from above
         image->writehist[image->md->wCBindex].writetime = ts;
         image->writehist[image->md->wCBindex].cnt0 = image->md->cnt0;

--- a/ImageStreamIO.h
+++ b/ImageStreamIO.h
@@ -10,10 +10,13 @@
 #ifndef _IMAGESTREAMIO_H
 #define _IMAGESTREAMIO_H
 
-#ifdef CLOCK_TAI
-#define CLOCK_ISIO CLOCK_TAI
-#else
-#define CLOCK_ISIO CLOCK_REALTIME
+//If CLOCK_ISIO is not defined, define it as CLOCK_TAI if available, fallback to CLOCK_REALTIME
+#ifndef CLOCK_ISIO
+    #ifdef CLOCK_TAI
+        #define CLOCK_ISIO CLOCK_TAI
+    #else
+        #define CLOCK_ISIO CLOCK_REALTIME
+    #endif
 #endif
 
 #ifdef __cplusplus
@@ -474,8 +477,8 @@ long ImageStreamIO_semvalue(
 
 
 /** @brief Update image metadata and post semaphores after image is updated
- * 
- * Increments counters, sets times, sets write flag to zero, and posts semaphores.  
+ *
+ * Increments counters, sets times, sets write flag to zero, and posts semaphores.
  * Should be called each time image content is updated
  *
  */
@@ -484,8 +487,8 @@ long ImageStreamIO_UpdateIm_atime( IMAGE *image,           ///< [out] pointer to
                                  );
 
 /** @brief Update image metadata and post semaphores after image is updated
- * 
- * Increments counters, sets times, sets write flag to zero, and posts semaphores.  
+ *
+ * Increments counters, sets times, sets write flag to zero, and posts semaphores.
  * Should be called each time image content is updated
  *
  * Acquisition time (atime) will be set to the write time.


### PR DESCRIPTION
Add `#ifndef` around CLOCK_ISIO and FILEMODE_ISIO to allow configuring at build time

I made it FILEMODE_ISIO to be symmetric with CLOCK_ISIO but it could be ISIO_FILEMODE.  

CLOCK_ISIO is slightly dangerous as is.  Maybe we need a function like `get_CLOCK_ISIO()` so library users don't have to keep track of how it was configured.  Granted most should use the  ImageStreamIO functions rather than setting timestamps themselves.