### PR TITLE
Fix large shmim size checks

### DIFF
--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -1778,7 +1778,7 @@ errno_t ImageStreamIO_read_sharedmem_image_toIMAGE(
     {
         file_stat.st_size = 0;
         fstat(SM_fd, &file_stat);
-        if ((int) file_stat.st_size <= (int) sizeof(IMAGE_METADATA))
+        if (file_stat.st_size <= (off_t) sizeof(IMAGE_METADATA))
         {
             close(SM_fd);
             ImageStreamIO_printERROR(IMAGESTREAMIO_FILEOPEN, "Error in the file (too small)");
@@ -1798,7 +1798,9 @@ errno_t ImageStreamIO_read_sharedmem_image_toIMAGE(
     image->md = (IMAGE_METADATA *)map_root;
 
     ierrno = ImageStreamIO_image_sizing(image, map_root);
-    if (IMAGESTREAMIO_SUCCESS != ierrno || ((int) image->memsize != (int) file_stat.st_size))
+    if (IMAGESTREAMIO_SUCCESS != ierrno
+            || file_stat.st_size < 0
+            || image->memsize != (uint64_t) file_stat.st_size)
     {
         ImageStreamIO_printERROR(IMAGESTREAMIO_FILEOPEN, "Error in the file");
         munmap(image->md, file_stat.st_size);


### PR DESCRIPTION
This work was performed by Codex (GPT-5).

## Summary

Fix large shared-memory image attach failures caused by narrowing file-size checks in `ImageStreamIO_read_sharedmem_image_toIMAGE()`.

When a shmim file grows past ~2 GB, the existing attach path casts both `file_stat.st_size` and `image->memsize` to `int`. That can truncate or wrap the size check, causing valid large shmim files to be rejected with errors like:

- `Error in the file (too small)`

This change removes those narrowing comparisons and uses wide, type-safe checks instead:

- compare `file_stat.st_size` against `sizeof(IMAGE_METADATA)` as `off_t`
- compare `image->memsize` against `file_stat.st_size` without truncating to `int`
- explicitly reject negative `st_size` before casting to `uint64_t`

## Effect

Large shmim files that were previously misclassified during attach should now open correctly, while preserving the existing validation logic for genuinely invalid files.
