### PR TITLE
Nanobind to dev [stacked onto #71]

### DIFF
--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -1440,15 +1440,6 @@ errno_t ImageStreamIO_createIm_gpu(
             return IMAGESTREAMIO_FAILURE;  // _filename did _printERROR
         }
 
-        // - Ensure GPU SHM buffer file does not exist
-        struct stat buffer;
-        if ((stat(SM_fname, &buffer) == 0) && (location > -1))
-        {
-            ImageStreamIO_printERROR(IMAGESTREAMIO_FILEEXISTS,
-                                     "Error creating GPU SHM buffer on an existing file");
-            return IMAGESTREAMIO_FILEEXISTS;
-        }
-
         char name_tmp[STRINGMAXLEN_IMAGE_NAME] = {0};
         strcat(name_tmp, name);
         strcat(name_tmp, "_tmpcreate");


### PR DESCRIPTION
Stacked PR on top of #71 .

Test stack in pyMilk + earlier bigfixes says that it's OK to recreate a GPU shim.
You'll leak, and existing references to the previous GPU SHM will become zombie and still work on a zombie memory segment until you autorelink, but it's no different that with CPU SHM.